### PR TITLE
Update charter to reflect current status

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Working Group participants may act in one or more of the following roles:
 ### Modifying this governance document
 
 Changes to this document will be made via Pull Request.
-The PR will be merged on 2 agreement from Approvers.
+The PR will be merged on 2 agreement from Maintainers.
 
 ## Reference projects
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,10 @@ The list is not meant to be exhaustive.
       * [Gazebo (formerly Ignition)](https://github.com/gazebosim/gz-sim)
     * Surface
       * [ASV Wave Simulator](https://github.com/srmainwaring/asv_wave_sim/tree/feature/fft_waves)
-      * [Virtual RobotX (VRX)](https://github.com/osrf/vrx): ROS and Gazebo-classic / new Gazebo
+      * [Virtual RobotX (VRX) competition](https://github.com/osrf/vrx): ROS and Gazebo-classic / new Gazebo
+      * [MBZIRC Maritime Grand Challenge Simulator](https://github.com/osrf/mbzirc): ROS 2 and Gazebo
+      * [MBARI Wave Energy Converter Simulator](https://github.com/osrf/mbari_wec): ROS 2 and Gazebo
+      * Sailboat and wind simulation of [Racing Sparrow 750](https://github.com/srmainwaring/rs750) and [Docker files](https://github.com/srmainwaring/sail_sim_docker)
     * Underwater
       * [UUV Simulator](https://uuvsimulator.github.io/): ROS and Gazebo-classic
       * [NPS Project DAVE](https://github.com/Field-Robotics-Lab/dave/wiki): ROS and Gazebo-classic

--- a/README.md
+++ b/README.md
@@ -154,11 +154,11 @@ The list is not meant to be exhaustive.
       * [Gazebo-classic](https://classic.gazebosim.org/)
       * [Gazebo (formerly Ignition)](https://github.com/gazebosim/gz-sim)
     * Surface
-      * [ASV Wave Simulator](https://github.com/srmainwaring/asv_wave_sim/tree/feature/fft_waves)
+      * [ASV Wave Simulator](https://github.com/srmainwaring/asv_wave_sim)
       * [Virtual RobotX (VRX) competition](https://github.com/osrf/vrx): ROS and Gazebo-classic / new Gazebo
       * [MBZIRC Maritime Grand Challenge Simulator](https://github.com/osrf/mbzirc): ROS 2 and Gazebo
       * [MBARI Wave Energy Converter Simulator](https://github.com/osrf/mbari_wec): ROS 2 and Gazebo
-      * Sailboat and wind simulation of [Racing Sparrow 750](https://github.com/srmainwaring/rs750) and [Docker files](https://github.com/srmainwaring/sail_sim_docker)
+      * Sailboat and wind simulation of [Racing Sparrow 750](https://github.com/srmainwaring/rs750)
     * Underwater
       * [UUV Simulator](https://uuvsimulator.github.io/): ROS and Gazebo-classic
       * [NPS Project DAVE](https://github.com/Field-Robotics-Lab/dave/wiki): ROS and Gazebo-classic

--- a/README.md
+++ b/README.md
@@ -2,78 +2,121 @@
 
 This document defines the scope and governance of the Working Group (WG).
 
-Mission: To unite, create and upgrade generic maritime robotics solutions that can be easily deployed in maritime robots. 
+Mission: To unite, create and upgrade generic marine robotics solutions that can be easily deployed in marine robots.
 
-Scope: ROS packages related to maritime robotics specificities of any robotics field: control, simulation, drivers... All maritime robots types are included, whether they are USV (Ummaned Surface Vehicle), AUV (Autonomous Underwater Vehicles), underwater manipulators...
+Scope: ROS packages related to marine robotics specificities of any robotics field: controls, simulation, drivers...
+All marine robot types are included, whether they are USV (Uncrewed Surface Vehicle), UUV (Uncrewed Underwater Vehicles), underwater manipulators...
 
-## Subprojects
+## Governance
 
-This Working Group maintains the following Subprojects.
-Its meetings and membership are largely focused on the direction, design, and work on the projects.
+### Meetings
 
-### Subproject List
+Everyone is welcome to attend the Working Group meetings.
+Just show up.
 
-The following projects, listed under Repositories, are affiliated with the Working Group.
+* Regular WG Meeting: Usually once a month on a Tuesday, at 8AM PST. Subjected to change.
+  * Meetings Announcement: Usually at least one week before the meeting in the [Maritime Robotics category](https://discourse.ros.org/c/maritime/36) on [ROS Discourse](https://discourse.ros.org/)
+  * Meeting agendas and minutes: [Google Doc](https://docs.google.com/document/d/1Wnddq4xRXR6HF2XFWeejfUGII_hj7DilKrGcFj1qlEA/edit?usp=drive_link)
+  * Outputs of the meetings: Recording as reply to the meeting announcement post
 
-Those listed under References are unaffiliated resources for reference. The references lists are not meant to be exhaustive.
+### Communication Channels
+
+* [ROS Discourse Maritime Robotics category](https://discourse.ros.org/c/maritime/36)
+  * Discourse tag: [wg-maritime-robotics](https://discourse.ros.org/tag/wg-maritime-robotics)
+* Github organization: [ros-maritime](https://github.com/ros-maritime)
+  * [Project board](https://github.com/orgs/ros-maritime/projects/1)
+* Google Group (only used to send meeting calendar invites): [Meeting invite group](https://groups.google.com/g/maritime-robotics-working-group-invites)
+* Instant messaging: [Matrix chat](https://matrix.to/#/#ros-maritime:matrix.org) (Matrix is an open network for secure, decentralized communication).
+
+### Participation and Organization
+
+Working Group participants may act in one or more of the following roles:
+
+* Participants / Contributors
+  * Attend meetings when convenient
+  * All attendees are welcome to contribute and review pull requests, and respond to issues, including but not limited to tickets in the [project board]((https://github.com/orgs/ros-maritime/projects/1))
+* Maintainers
+  * Prerequisite: Proven track record of high-quality contributions and reviews to repositories related to WG
+  * Responsible for approving and merging pull requests
+* Organizers
+  * Responsible for organizing and moderating working group meetings
+  * Responsible for posting meeting materials (minutes, recordings, etc.)
+  * Responsible for breaking ties
+
+### Modifying this governance document
+
+Changes to this document will be made via Pull Request.
+The PR will be merged on 2 agreement from Approvers.
+
+## Reference projects
+
+The following projects may be generally useful for those working in marine
+robotics with ROS.
+
+Some projects are affiliated with the Working Group, and their progress may be
+discussed in WG meetings.
+The [Project board](https://github.com/orgs/ros-maritime/projects/1) keeps
+track of a subset of those projects.
+
+### Projects List
+
+The list is not meant to be exhaustive.
 
 * Communication
   * Description: Packages for underwater network wireless communication.
   * Motive: Since underwater communications relies on acoustic waves, there are some specificities regarding these types of waves that should be taken into account during data transmission.
-  * Repositories
-    * Suggestions...
-  * References: 
+  * References
     * [ns UAN](https://www.nsnam.org/docs/models/html/uan.html)
     * [WHOI `ros_acomms`](https://git.whoi.edu/acomms/ros_acomms)
 
 * Common Messages
   * Description: Specific ROS messages for maritime robotics.
   * Motive: There are maritime robotics sensors that give specific types of messages.
-  * Unique Repo
-    * Assist the development of [UW APL Hydrographic Messages](https://github.com/apl-ocean-engineering/hydrographic_msgs)
+  * References
+    * [UW APL Hydrographic Messages](https://github.com/apl-ocean-engineering/hydrographic_msgs)
 
 * Drivers
   * Description: Documentation and index for underwater and surface vehicles sensors and actuators drivers.
   * Motive: There are specific components used only for maritime robotics, which requires drivers to interact with them. Although, there already is an ROS organization to develop ROS drivers, so instead of developing inside this organization, we would use it just to have an index describing maritimate focused ROS drivers.
-  * Unique Repo
+  * Proposal
     * **[Proposal]** ROS Maritime Robotics Drivers Index
     * **[Proposal]** Sonar and radar drivers
-  * References: 
+  * References
     * [ROS Drivers](https://github.com/ros-drivers)
 
 * Documentation
   * Description: Documentation and index for maritime robotics packages and organizations.
   * Motive: There are already many organizations and repos for maritime robotics. It is important to map what it is already developed in the area as well as make tutorials for newcomers or people that want to contribute with maritime robotics development.
-  * Repositories
+  * Proposal
     * **[Proposal]** ROS Maritime Robotics Documentation Index
     * **[Proposal]** ROS Maritime Robotics Tutorials
-  * References: 
+  * References
     * Marine-specific software architecture
       * [COLA2](https://iquarobotics.com/cola2): ROS and Gazebo
 
 * Dynamic Model
   * Description: Packages related to estimation and iteration of maritime robots models.
-  * Motive: Maritime robots dynamical models have to take into account buoyancy, hydrodynamics... Therefore some packages regarding math models are needed. 
-  * Repositories
+  * Motive: Maritime robots dynamical models have to take into account buoyancy, hydrodynamics... Therefore some packages regarding math models are needed.
+  * Proposal
     * **[Proposal]** Maritime vehicle model estimation based experiments
       * Use control, pose and velocity bags and URDF to estimate the Fossen equation of motion parameters
     * **[Proposal]** Maritime vehicle model iterator
       * Use vehicle equations of motion to predict the robot's next position and velocity. This can be used with localization and control algorithms.
 
-* Guidance, Navigation and Control (GNC)  
+* Guidance, Navigation and Control (GNC)
   * Description: Packages for GNC of maritime robots.
   * Motive: There are some controls and tasks specifics to maritime robots, such as thruster control allocation, surveillance, vessels' handling of tides...
-  * Repositories
+  * Proposal
     * **[Proposal]** Thruster manager
-  * References: 
+  * References
     * [Plankton thruster manager](https://github.com/Liquid-ai/Plankton/blob/master/uuv_control/uuv_thruster_manager/src/uuv_thrusters/thruster_manager.py)
- 
+
 * Localization
   * Description: Packages to localize maritime vehicles.
-  * Motive: Underwater and surface vehicles have a lot of differences regarding the sensors they can use for localizing themselves. GPS does not work underwater, as well as lidars or electromagnetic waves for long distances... But acoustic waves work pretty well, so underwater localization rely more on sensors like DVL and Sonar, that uses acoustic waves to measure distance and velocity.  
-  * Repositories:
+  * Motive: Underwater and surface vehicles have a lot of differences regarding the sensors they can use for localizing themselves. GPS does not work underwater, as well as lidars or electromagnetic waves for long distances... But acoustic waves work pretty well, so underwater localization rely more on sensors like DVL and Sonar, that uses acoustic waves to measure distance and velocity.
+  * Proposal
     * **[Proposal]**: Multilateration of acoustic beacons
-  * References: 
+  * References
     * [Mesh Navigation](https://github.com/uos/mesh_navigation)
     * [Fuse Localization](https://github.com/uos/mesh_navigation)
     * [MagNav](https://www.gpsworld.com/us-air-force-to-explore-navigating-with-magnetism/)
@@ -81,143 +124,54 @@ Those listed under References are unaffiliated resources for reference. The refe
 * Perception
   * Description: Packages for perception algorithms for maritime robotics.
   * Motive: Since there are different sensors such as sonars, there is a need to process this data to obtain information. Moreover, it can be created some common structures detection.
-  * Repositories:
+  * Proposal
     * **[Proposal]**: Common Maritime Environments Detections (buoys, valves, pipes...)
     * **[Proposal]**: Fusion of sonar and camera data
-  * References: 
-    * Suggestions...
-   
+
 * Robots
   * Description: Packages with maritime robots and structures.
   * Motive: All the software being developed shall have not only unit tests but integration tests, so robots and structures shall be developed for this purpose. These shall include vcstool for specifying packages to be used with the robot as well as ros_ign_bridge to test it in simulation.
-  * Repositories
+  * Proposal
     * **[Proposal]** Hover type UW vehicle
     * **[Proposal]** Torpedo shaped UW vehicle
     * **[Proposal]** USV
-    * **[Proposal]** Intervention UW vehicle 
-  * References: 
+    * **[Proposal]** Intervention UW vehicle
+  * References
     * Intervention UW sample [RexROV2](https://uuvsimulator.github.io/packages/rexrov2/intro/)
-    * Torpedo Shaped UW vehicle [LRAUV](https://github.com/osrf/lrauv/)
+    * Torpedo Shaped UW vehicle [MBARI LRAUV](https://github.com/osrf/lrauv/)
 
 * Simulation
   * Description: Documentation and index for maritime robotics Gazebo plugins.
-  * Motive: There is no need to mix ROS code with simulation, also there is already some maritime robotics development in Ignition, so it is a good thing to contribute to ign-gazebo repo instead of creating other in this organization.
-  * Repositories
+  * Motive: There is no need to mix ROS code with simulation, also there is already some maritime robotics development in new Gazebo, so it is a good thing to contribute to ign-gazebo repo instead of creating other in this organization.
+  * Proposal
     * **[Proposal]** Maritime Robotics Gazebo Plugins Index
-    * **[Proposal]** Wave Simulation (repo shall be in ign-plugins)
-    * **[Proposal]** Acoustics Simulation (repo shall be in ign-plugins) (Include salinity and temperature effects)
-    * **[Proposal]** Radar Simulation (repo shall be in ign-plugins)
-    * **[Proposal]** Sonar Simulation (repo shall be in ign-plugins)
-  * References: 
+    * **[Proposal]** Wave Simulation
+    * **[Proposal]** Acoustics Simulation (include salinity and temperature effects)
+    * **[Proposal]** Radar Simulation
+    * **[Proposal]** Sonar Simulation
+  * References
     * General
       * [Gazebo-classic](https://classic.gazebosim.org/)
-      * [Gazebo Sim (formerly Ignition)](https://github.com/gazebosim/gz-sim)
+      * [Gazebo (formerly Ignition)](https://github.com/gazebosim/gz-sim)
     * Surface
       * [ASV Wave Simulator](https://github.com/srmainwaring/asv_wave_sim/tree/feature/fft_waves)
-      * [Virtual RobotX (VRX)](https://github.com/osrf/vrx): ROS and Gazebo
+      * [Virtual RobotX (VRX)](https://github.com/osrf/vrx): ROS and Gazebo-classic / new Gazebo
     * Underwater
-      * [UUV Simulator](https://uuvsimulator.github.io/): ROS and Gazebo
-      * [NPS Project DAVE](https://github.com/Field-Robotics-Lab/dave/wiki): ROS and Gazebo
-      * [Plankton](https://github.com/Liquid-ai/Plankton): ROS2 and Gazebo
-      * [Ignition native underwater vehicles](https://gazebosim.org/api/gazebo/6.4/underwater_vehicles.html): Ignition
-      * [MBARI LRAUV simulated in Ignition](https://github.com/osrf/lrauv/): Ignition
-      * [WHOI Deep Submergence Lab ds_sim](https://bitbucket.org/whoidsl/ds_sim/src/master/): ROS and Gazebo
+      * [UUV Simulator](https://uuvsimulator.github.io/): ROS and Gazebo-classic
+      * [NPS Project DAVE](https://github.com/Field-Robotics-Lab/dave/wiki): ROS and Gazebo-classic
+      * [Plankton](https://github.com/Liquid-ai/Plankton): ROS 2 and Gazebo-classic
+      * [Gazebo native underwater vehicles](https://gazebosim.org/api/gazebo/6.4/underwater_vehicles.html): Gazebo
+      * [MBARI LRAUV simulation](https://github.com/osrf/lrauv/): Gazebo
+      * [WHOI Deep Submergence Lab ds_sim](https://bitbucket.org/whoidsl/ds_sim/src/master/): ROS and Gazebo-classic
 
 * Tools
   * Description: Extra category for packages that do something specific that don't fit in any other category
-  * Motive: There might be some tools that can be developed for maritime robotics that doesn't fit another category, such as geographic information convertion. 
-  * Repositories
+  * Motive: There might be some tools that can be developed for maritime robotics that doesn't fit another category, such as geographic information convertion.
+  * Proposal
     * **[Proposal]** Geographic convertions
-  * References: 
-    * Suggestions...
 
 * Data sets
   * Description: Marine-specific data sets
   * Motive: Underwater sensors differ a great deal from land sensors, and data sets obtained using underwater sensors are necessary for realistic underwater algorithmic development.
-  * References:
+  * References
     * [LearnOpenCV tutorial on Underwater Trash Detection](https://learnopencv.com/yolov6-custom-dataset-training/)
-
-### Standards for subprojects
-
-Subprojects must meet the following criteria (and the WG agrees to maintain them upon adoption).
-
-* Build passes against ROS master
-* The ROS standard linter set is enabled and adhered to
-* If packages are part of nightly builds on the ROS build farm, there are no reported warnings or test failures
-* Quality builds are green (address sanitizer, thread sanitizer, clang thread safety analysis)
-* Test suite passes
-* Code coverage is measured, and non-decreasing level is enforced in PRs
-* Issues and pull requests receive prompt responses
-* Releases go out regularly when bugfixes or new features are introduced
-* The backlog is maintained, avoiding longstanding stale issues
-
-### Adding new subprojects
-
-To request introduction of a new subproject, add a list item to the "Subprojects" section and open a Pull Request to this repository, following the default Pull Request Template to populate the text of the PR.
-
-PR will be merged on unanimous approval from Approvers.
-
-### Subproject changes
-
-Modify the relevant list item in the "Subprojects" section and open a Pull Request to this repository, following the default Pull Request Template to populate the text of the PR.
-
-PR will be merged on unanimous approval from Approvers.
-
-### Deprecating subprojects
-
-Projects cease to be useful, or the WG can decide it is no longer in their interest to maintain.
-We do not commit to maintaining every subproject in perpetuity.
-
-To suggest removal of a subproject, remove the relevant list item in the "Subprojects" section and open a Pull Request in this repository, following instructions in the Pull Request Template to populate the text of the PR.
-
-PR will be merged on unanimous approval from Approvers.
-
-If the repositories of the subproject are under the WG's GitHub organization, they will be transferred out of the organization or deleted at this time.
-
-## Governance
-
-### Meetings
-
-* Regular WG Meeting: First Tuesday of every month at 8AM PST
-  * Meetings Announcement: One week before the meeting in the [Maritime Robotics category](https://discourse.ros.org/c/maritime/36) on [ROS Discourse](https://discourse.ros.org/)
-  * Outputs of the meetings: Recording and minutes of the meeting in the [Maritime Robotics category](https://discourse.ros.org/c/maritime/36) on [ROS Discourse](https://discourse.ros.org/)
-
-### Communication Channels
-
-* Instant messaging: [Matrix community](https://matrix.to/#/#ros-maritime:matrix.org) (Matrix is an open network for secure, decentralized communication).
-* Google Group: [Meeting invite group](https://groups.google.com/g/maritime-robotics-working-group-invites)
-* Github organization: [ros-maritime](https://github.com/ros-maritime)
-* Discourse tag: [wg-maritime-robotics](https://discourse.ros.org/tag/wg-maritime-robotics)
-
-### Backlog Management
-
-Each project shall discuss and define its goals in element.
-
-### Membership, Roles and Organization Management
-
-Working Group members may act in one or more of the following roles:
-
-* **Member**
-  * Prerequisite: Attend at least one out of the last three Working Group meetings
-  * Responsible for triaging issues
-* **Reviewer**
-  * All reviewers are members
-  * Prerequisite: Proven track record of high-quality reviews to WG Subprojects
-  * Responsible for reviewing pull requests
-* **Approver**
-  * All approvers are reviewers
-  * Prerequisite: Proven track record of high-quality contributions and reviews to WG Subprojects
-  * Responsible for approving and merging pull requests
-  * Responsible for vetting and accepting new projects into the Working Group
-* **Lead**
-  * Responsible for organizing and moderating working group meetings
-  * Responsible for posting meeting materials (minutes, recordings, etc.)
-  * Responsible for breaking ties
-
-To become a member or change role, create an issue in this repository using the appropriate issue template.
-Such applications are accepted upon unanimous agreement from Approvers, and are typically based on the applicant's history with the subprojects of the Working Group. The Lead role cannot be applied for.
-
-### Modifying this governance document
-
-Changes to this document will be made via Pull Request.
-The PR will be merged on 2 agreement from Approvers.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Working Group participants may act in one or more of the following roles:
 ### Modifying this governance document
 
 Changes to this document will be made via Pull Request.
-The PR will be merged on 2 agreement from Maintainers.
+The PR will be merged on 1 maintainer approval.
 
 ## Reference projects
 


### PR DESCRIPTION
# Modify Governance Model

As Arjo and I discussed

Updating WG charter to reflect the current status:
- Move governance to the top so the key WG links are easily seen
- Update participant roles to be more lenient, since we don’t have formal membership
- Replace “subprojects” with “reference projects,” “Repositories” with “Proposals” since they’re all proposals. Remove rules about subprojects, since we do not anticipate the time and labor to maintain code in the near future. We can add the structure back as the need and availability arise.

Terminology:
- Replace “unmanned” with ungendered term “uncrewed.” I didn’t change to autonomous because there is a difference between uncrewed (e.g. remotely operated vehicles) and autonomous. All autonomous vehicles are uncrewed, but not all uncrewed vehicles are autonomous. So it is a more inclusive term.
- Replace some instances of “maritime” with “marine.” It is a more inclusive term. All maritime (seafaring, traveling, shipping) vehicles may be considered marine, but not all marine vehicles (e.g. used in underwater science) are maritime. I didn’t touch the name of the WG.